### PR TITLE
若干完成毕设期间做的修改

### DIFF
--- a/pages/graduate-cover.typ
+++ b/pages/graduate-cover.typ
@@ -92,18 +92,14 @@
           "所在学院：", info.department,
           grid.cell(stroke: none)[], grid.cell(stroke: none)[],
         )
-      ],
-    )
-
-    block(
-      width: 50%,
-      [
-        #set text(size: 字号.小三, weight: "bold")
-        #grid(
-          columns: (0.5fr, 0.3fr),
-          align: (start, center),
-          "论文提交日期", info.submit-date,
-        )
+        #align(right)[
+          #set text(size: 字号.小三, weight: "bold")
+          #grid(
+            columns: (auto, 10.5em),
+            align: (start, center),
+            "论文提交日期", info.submit-date,
+          )
+        ]
       ],
     )
   }

--- a/pages/template-individual.typ
+++ b/pages/template-individual.typ
@@ -1,9 +1,11 @@
 #import "../utils/fonts.typ": 字号, 字体
 #import "../utils/datetime-display.typ": datetime-display
 #import "../utils/twoside.typ": twoside-pagebreak
+#import "../utils/indent-first-par.typ": fake-par
 
 #let template-individual(
   outlined: false,
+  indent-first-par: true,
   titlelevel: 2,
   bodytext-settings: (size: 字号.四号),
   pagetitle,
@@ -26,6 +28,9 @@
     block(width: 100%)[
       #set par(justify: true)
       #set text(..bodytext-settings)
+      #if indent-first-par {
+        fake-par
+      }
       #s
     ]
 

--- a/pages/template-individual.typ
+++ b/pages/template-individual.typ
@@ -35,6 +35,6 @@
     ]
 
 
-
+    twoside-pagebreak
   }
 }

--- a/utils/header.typ
+++ b/utils/header.typ
@@ -9,9 +9,9 @@
   right: none,
   center: none,
 ) = {
-  set text(font: font, size: size)
-  locate(loc => {
-    if not (query(<mzt:no-header-footer>, loc).filter(el => el.location().page() == loc.page()) != ()) {
+  context {
+    if query(<mzt:no-header-footer>).filter(el => el.location().page() == here().page()) == () {
+      set text(font: font, size: size)
       stack(
         spacing: spacing,
         grid(
@@ -30,12 +30,15 @@
         line(length: 100%, stroke: stroke),
       )
     }
-
-  })
+  }
 }
 
-#let footer(left: none, right: none, center: none) = locate(loc => {
-  if not (query(<mzt:no-header-footer>, loc).filter(el => el.location().page() == loc.page()) != ()) {
+#let footer(
+  left: none,
+  right: none,
+  center: none
+) = context {
+  if query(<mzt:no-header-footer>).filter(el => el.location().page() == here().page()) == () {
     let fleft(numbering) = {
       if type(left) == function {
         left(numbering)
@@ -71,4 +74,4 @@
       )
     ]
   }
-})
+}

--- a/utils/indent-first-par.typ
+++ b/utils/indent-first-par.typ
@@ -5,7 +5,11 @@
 #let indent-first-par(s) = {
   let indent-next-par(s) = {
     s
-    fake-par
+    context {
+      if query(metadata.where(value: <mzt:continue-par>)).filter(el => el.location().position() == here().position()) == () {
+        fake-par
+      }
+    }
   }
   show heading: indent-next-par
   show list: indent-next-par
@@ -14,3 +18,4 @@
   show math.equation.where(block: true): indent-next-par
   s
 }
+#let continue-par = metadata(<mzt:continue-par>)

--- a/utils/indent-first-par.typ
+++ b/utils/indent-first-par.typ
@@ -3,10 +3,14 @@
 #let empty-par = par[#box()]
 #let fake-par = context empty-par + v(-measure(empty-par + empty-par).height)
 #let indent-first-par(s) = {
-  show heading: it => {
-    it
-
+  let indent-next-par(s) = {
+    s
     fake-par
   }
+  show heading: indent-next-par
+  show list: indent-next-par
+  show enum: indent-next-par
+  show figure: indent-next-par
+  show math.equation.where(block: true): indent-next-par
   s
 }

--- a/utils/structure.typ
+++ b/utils/structure.typ
@@ -6,6 +6,7 @@
 
 #let mainmatter(s) = {
   set page(numbering: "1")
+  set par(spacing: 1.3em)
   counter(page).update(1)
   s
 }

--- a/utils/twoside.typ
+++ b/utils/twoside.typ
@@ -22,12 +22,12 @@
   show metadata.where(value: <mzt:twoside-numbering-footer>): [
     #if twoside {
       footer(
-        left: numbering => locate(loc => if calc.even(loc.page()) {
+        left: numbering => if calc.even(here().page()) {
           numbering
-        }),
-        right: numbering => locate(loc => if not calc.even(loc.page()) {
+        },
+        right: numbering => if not calc.even(here().page()) {
           numbering
-        }),
+        },
       )
     } else {
       footer(center: numbering => numbering)


### PR DESCRIPTION
硕士论文初稿写完了，来把做的一些修改提过来。各提交的修改内容按时间序如下：

1. 修改了封面的“论文提交日期”部分，使其更长且右端与上面对齐，和 Word 版的示例更像
2. `template-individual` 增加了一个 `indent-first-par` 的参数，给摘要的第一段做缩进
3. `template-individual` 的末尾增加了一个 `twoside-pagebreak`，否则当表目录为奇数页时，页码 1 会出现在表目录最后的偶数页空页上，正文第一页的页码会变成 2
4. 使用 `context` + `here` 修改了 `twoside.typ` 和 `header.typ` 中的部分，代替原来标记了 deprecated 的写法，且原来的写法会导致参考文献部分的页码都出现在右侧，无论实际是奇数页还是偶数页
5. 在 `mainmatter` 中，同样设置段间距为和行间距一样的 1.3em，默认的 1.2em 下能看到正文中两段间的距离比行间距还小一点；加在 `mainmatter` 是防止破坏前面几页的格式
6. 在 `indent-first-par` 中，同样对 list、enum、figure、block equation 做相同的操作，否则也会丢失其下一段的缩进