### PR TITLE
fix(title-case csl): remove uppercase config for translator and editor

### DIFF
--- a/assets/gb-t-7714-2015-numeric-bilingual-title-case.csl
+++ b/assets/gb-t-7714-2015-numeric-bilingual-title-case.csl
@@ -200,7 +200,7 @@
     <macro name="secondary-contributors">
         <names variable="translator">
             <name>
-                <name-part name="family" text-case="uppercase" />
+                <name-part name="family" />
             </name>
             <institution />
             <label form="short" prefix=", " />
@@ -210,7 +210,7 @@
     <macro name="container-contributors">
         <names variable="editor">
             <name>
-                <name-part name="family" text-case="uppercase" />
+                <name-part name="family" />
             </name>
             <institution />
             <substitute>


### PR DESCRIPTION
before
<img width="890" height="160" alt="image" src="https://github.com/user-attachments/assets/0968616e-4fba-4bbd-baa4-34f097edc453" />
after
<img width="868" height="168" alt="image" src="https://github.com/user-attachments/assets/ce7e58ec-9f5c-4074-ab4e-de0265c34337" />
